### PR TITLE
feat/ParticleSystemComponent

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Container/Array.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Core/Container/Array.h
@@ -61,6 +61,8 @@ public:
     void Init(const T& Element, SizeType Number);
     SizeType Add(const T& Item);
     SizeType Add(T&& Item);
+    SizeType AddZeroed();
+    SizeType AddZeroed(SizeType Number);
     SizeType AddUnique(const T& Item);
 
     template <typename... Args>
@@ -315,6 +317,26 @@ template <typename T, typename AllocatorType>
 typename TArray<T, AllocatorType>::SizeType TArray<T, AllocatorType>::Add(T&& Item)
 {
     return Emplace(std::move(Item));
+}
+
+
+template <typename T, typename AllocatorType>
+typename TArray<T, AllocatorType>::SizeType TArray<T, AllocatorType>::AddZeroed()
+{
+    const SizeType Index = Num();
+    Add(T{});  // 기본 생성된 요소 추가
+    return Index;
+}
+
+template <typename T, typename AllocatorType>
+typename TArray<T, AllocatorType>::SizeType TArray<T, AllocatorType>::AddZeroed(SizeType Number)
+{
+    const SizeType Index = Num();
+    for(SizeType i = 0; i < Number; ++i)
+    {
+        Add(T{});  // 기본 생성된 요소 추가
+    }
+    return Index;
 }
 
 template <typename T, typename AllocatorType>

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ParticleSystemComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ParticleSystemComponent.h
@@ -38,6 +38,8 @@ public:
     /** This is created at start up and then added to each emitter */
     float EmitterDelay;
 
+    /** Indicates that the component has not been ticked since being registered. */
+    uint8 bJustRegistered:1;
 private:
     float DeltaTimeTick;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ParticleSystemComponent.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ParticleSystemComponent.h
@@ -35,6 +35,9 @@ public:
     /** Stream of random values to use with this component */
     FRandomStream RandomStream;
 
+    /** This is created at start up and then added to each emitter */
+    float EmitterDelay;
+
 private:
     float DeltaTimeTick;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleComponents.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleComponents.cpp
@@ -1,11 +1,931 @@
+#include "ParticleLODLevel.h"
+#include "ParticleModuleRequired.h"
+#include "ParticleSpriteEmitter.h"
 #include "Components/ParticleSystemComponent.h"
+#include "Lifetime/ParticleModuleLifetimeBase.h"
 
 #include "Particles/ParticleEmitter.h"
 #include "Particles/ParticleSystem.h"
+#include "TypeData/ParticleModuleTypeDataBase.h"
+#include "UObject/Casts.h"
+#include "UObject/ObjectFactory.h"
+
+/*-----------------------------------------------------------------------------
+    UParticleLODLevel implementation.
+-----------------------------------------------------------------------------*/
+UParticleLODLevel::UParticleLODLevel()
+{
+    bEnabled = true;
+    ConvertedModules = true;
+    PeakActiveParticles = 0;
+}
+
+int32 UParticleLODLevel::GetModuleIndex(UParticleModule* InModule)
+{
+    if (InModule)
+    {
+        if (InModule == RequiredModule)
+        {
+            return INDEX_REQUIREDMODULE;
+        }
+        else if (InModule == SpawnModule)
+        {
+            return INDEX_SPAWNMODULE;
+        }
+        else if (InModule == TypeDataModule)
+        {
+            return INDEX_TYPEDATAMODULE;
+        }
+        else
+        {
+            for (int32 ModuleIndex = 0; ModuleIndex < Modules.Num(); ModuleIndex++)
+            {
+                if (InModule == Modules[ModuleIndex])
+                {
+                    return ModuleIndex;
+                }
+            }
+        }
+    }
+
+    return INDEX_NONE;
+}
+
+UParticleModule* UParticleLODLevel::GetModuleAtIndex(int32 InIndex)
+{
+    // 'Normal' modules
+    if (InIndex > INDEX_NONE)
+    {
+        if (InIndex < Modules.Num())
+        {
+            return Modules[InIndex];
+        }
+
+        return NULL;
+    }
+
+    switch (InIndex)
+    {
+    case INDEX_REQUIREDMODULE:		return RequiredModule;
+    case INDEX_SPAWNMODULE:			return SpawnModule;
+    case INDEX_TYPEDATAMODULE:		return TypeDataModule;
+    }
+
+    return NULL;
+}
+
+void UParticleLODLevel::CompileModules( FParticleEmitterBuildInfo& EmitterBuildInfo )
+{
+    //check( RequiredModule );
+    //check( SpawnModule );
+
+    // Store a few special modules.
+    EmitterBuildInfo.RequiredModule = RequiredModule;
+    EmitterBuildInfo.SpawnModule = SpawnModule;
+
+    // Compile those special modules.
+    RequiredModule->CompileModule( EmitterBuildInfo );
+    if ( SpawnModule->bEnabled )
+    {
+        SpawnModule->CompileModule( EmitterBuildInfo );
+    }
+
+    // Compile all remaining modules.
+    const int32 ModuleCount = Modules.Num();
+    for ( int32 ModuleIndex = 0; ModuleIndex < ModuleCount; ++ModuleIndex )
+    {
+        UParticleModule* Module = Modules[ModuleIndex];
+        if ( Module && Module->bEnabled )
+        {
+            Module->CompileModule( EmitterBuildInfo );
+        }
+    }
+
+    // Estimate the maximum number of active particles.
+    EmitterBuildInfo.EstimatedMaxActiveParticleCount = CalculateMaxActiveParticleCount();
+}
+
+void UParticleLODLevel::UpdateModuleLists()
+{
+	//LLM_SCOPE(ELLMTag::Particles);
+
+	SpawningModules.Empty();
+	SpawnModules.Empty();
+	UpdateModules.Empty();
+	// OrbitModules.Empty();
+	// EventReceiverModules.Empty();
+	// EventGenerator = NULL;
+
+	UParticleModule* Module;
+	int32 TypeDataModuleIndex = -1;
+
+	for (int32 i = 0; i < Modules.Num(); i++)
+	{
+		Module = Modules[i];
+		if (!Module)
+		{
+			continue;
+		}
+
+		if (Module->bSpawnModule)
+		{
+			SpawnModules.Add(Module);
+		}
+		if (Module->bUpdateModule || Module->bFinalUpdateModule)
+		{
+			UpdateModules.Add(Module);
+		}
+
+		if (Module->IsA(UParticleModuleTypeDataBase::StaticClass()))
+		{
+			TypeDataModule = CastChecked<UParticleModuleTypeDataBase>(Module);
+			if (!Module->bSpawnModule && !Module->bUpdateModule)
+			{
+				// For now, remove it from the list and set it as the TypeDataModule
+				TypeDataModuleIndex = i;
+			}
+		}
+		else
+		if (Module->IsA(UParticleModuleSpawnBase::StaticClass()))
+		{
+			UParticleModuleSpawnBase* SpawnBase = CastChecked<UParticleModuleSpawnBase>(Module);
+			SpawningModules.Add(SpawnBase);
+		}
+	}
+
+	if (TypeDataModuleIndex != -1)
+	{
+		Modules.RemoveAt(TypeDataModuleIndex);
+	}
+
+	if (TypeDataModule /**&& (Level == 0)**/)
+	{
+		// UParticleModuleTypeDataMesh* MeshTD = Cast<UParticleModuleTypeDataMesh>(TypeDataModule);
+		// if (MeshTD
+		// 	&& MeshTD->Mesh
+		// 	&& MeshTD->Mesh->HasValidRenderData(false))
+		// {
+		// 	UParticleSpriteEmitter* SpriteEmitter = Cast<UParticleSpriteEmitter>(GetOuter());
+		// 	if (SpriteEmitter && (MeshTD->bOverrideMaterial == false))
+		// 	{
+		// 		FStaticMeshSection& Section = MeshTD->Mesh->GetRenderData()->LODResources[0].Sections[0];
+		// 		UMaterialInterface* Material = MeshTD->Mesh->GetMaterial(Section.MaterialIndex);
+		// 		if (Material)
+		// 		{
+		// 			RequiredModule->Material = Material;
+		// 		}
+		// 	}
+		// }
+	}
+}
+
+int32	UParticleLODLevel::CalculateMaxActiveParticleCount()
+{
+	//check(RequiredModule != NULL);
+
+	// Determine the lifetime for particles coming from the emitter
+	float ParticleLifetime = 0.0f;
+	float MaxSpawnRate = SpawnModule->GetEstimatedSpawnRate();
+	int32 MaxBurstCount = SpawnModule->GetMaximumBurstCount();
+	for (int32 ModuleIndex = 0; ModuleIndex < Modules.Num(); ModuleIndex++)
+	{
+		UParticleModuleLifetimeBase* LifetimeMod = Cast<UParticleModuleLifetimeBase>(Modules[ModuleIndex]);
+		if (LifetimeMod != NULL)
+		{
+			ParticleLifetime += LifetimeMod->GetMaxLifetime();
+		}
+
+		UParticleModuleSpawnBase* SpawnMod = Cast<UParticleModuleSpawnBase>(Modules[ModuleIndex]);
+		if (SpawnMod != NULL)
+		{
+			MaxSpawnRate += SpawnMod->GetEstimatedSpawnRate();
+			MaxBurstCount += SpawnMod->GetMaximumBurstCount();
+		}
+	}
+
+	// Determine the maximum duration for this particle system
+	float MaxDuration = 0.0f;
+	float TotalDuration = 0.0f;
+	int32 TotalLoops = 0;
+	if (RequiredModule != NULL)
+	{
+		// We don't care about delay wrt spawning...
+		MaxDuration = FMath::Max<float>(RequiredModule->EmitterDuration, RequiredModule->EmitterDurationLow);
+		TotalLoops = RequiredModule->EmitterLoops;
+		TotalDuration = MaxDuration * TotalLoops;
+	}
+
+	// Determine the max
+	int32 MaxAPC = 0;
+
+	if (TotalDuration != 0.0f)
+	{
+		if (TotalLoops == 1)
+		{
+			// Special case for one loop... 
+			if (ParticleLifetime < MaxDuration)
+			{
+				MaxAPC += FMath::CeilToInt(ParticleLifetime * MaxSpawnRate);
+			}
+			else
+			{
+				MaxAPC += FMath::CeilToInt(MaxDuration * MaxSpawnRate);
+			}
+			// Safety zone...
+			MaxAPC += 1;
+			// Add in the bursts...
+			MaxAPC += MaxBurstCount;
+		}
+		else
+		{
+			if (ParticleLifetime < MaxDuration)
+			{
+				MaxAPC += FMath::CeilToInt(ParticleLifetime * MaxSpawnRate);
+			}
+			else
+			{
+				MaxAPC += (FMath::CeilToInt(FMath::CeilToInt(MaxDuration * MaxSpawnRate) * ParticleLifetime));
+			}
+			// Safety zone...
+			MaxAPC += 1;
+			// Add in the bursts...
+			MaxAPC += MaxBurstCount;
+			if (ParticleLifetime > MaxDuration)
+			{
+				MaxAPC += MaxBurstCount * FMath::CeilToInt(ParticleLifetime - MaxDuration);
+			}
+		}
+	}
+	else
+	{
+		// We are infinite looping... 
+		// Single loop case is all we will worry about. Safer base estimate - but not ideal.
+		if (ParticleLifetime < MaxDuration)
+		{
+			MaxAPC += FMath::CeilToInt(ParticleLifetime * FMath::CeilToInt(MaxSpawnRate));
+		}
+		else
+		{
+			if (ParticleLifetime != 0.0f)
+			{
+				if (ParticleLifetime <= MaxDuration)
+				{
+					MaxAPC += FMath::CeilToInt(MaxDuration * MaxSpawnRate);
+				}
+				else //if (ParticleLifetime > MaxDuration)
+				{
+					MaxAPC += FMath::CeilToInt(MaxDuration * MaxSpawnRate) * ParticleLifetime;
+				}
+			}
+			else
+			{
+				// No lifetime, no duration...
+				MaxAPC += FMath::CeilToInt(MaxSpawnRate);
+			}
+		}
+		// Safety zone...
+		MaxAPC += FMath::Max<int32>(FMath::CeilToInt(MaxSpawnRate * 0.032f), 2);
+		// Burst
+		MaxAPC += MaxBurstCount;
+	}
+
+	PeakActiveParticles = MaxAPC;
+
+	return MaxAPC;
+}
+
+/*-----------------------------------------------------------------------------
+    UParticleEmitter implementation.
+-----------------------------------------------------------------------------*/
+UParticleEmitter::UParticleEmitter()
+    : bDisabledLODsKeepEmitterAlive(false)
+    , QualityLevelSpawnRateScale(1.0f)
+    , DetailModeBitmask(0xFFFF) //PDM_DefaultValue
+{
+    // Structure to hold one-time initialization
+    struct FConstructorStatics
+    {
+        FName NAME_Particle_Emitter;
+        FConstructorStatics()
+            : NAME_Particle_Emitter(TEXT("Particle Emitter"))
+        {
+        }
+    };
+    static FConstructorStatics ConstructorStatics;
+
+    EmitterName = ConstructorStatics.NAME_Particle_Emitter;
+    ConvertedModules = true;
+    PeakActiveParticles = 0;
+#if WITH_EDITORONLY_DATA
+    EmitterEditorColor = FColor(0, 150, 150, 255);
+#endif // WITH_EDITORONLY_DATA
+
+}
+
+FParticleEmitterInstance* UParticleEmitter::CreateInstance(UParticleSystemComponent* InComponent)
+{
+    return NULL; 
+}
+
+void UParticleEmitter::UpdateModuleLists()
+{
+    for (int32 LODIndex = 0; LODIndex < LODLevels.Num(); LODIndex++)
+    {
+        UParticleLODLevel* LODLevel = LODLevels[LODIndex];
+        if (LODLevel)
+        {
+            LODLevel->UpdateModuleLists();
+        }
+    }
+    Build();
+}
+
+void UParticleEmitter::SetEmitterName(FName Name)
+{
+    EmitterName = Name;
+}
+
+FName& UParticleEmitter::GetEmitterName()
+{
+    return EmitterName;
+}
+
+void UParticleEmitter::SetLODCount(int32 LODCount)
+{
+    // 
+}
+
+int32 UParticleEmitter::CreateLODLevel(int32 LODLevel, bool bGenerateModuleData)
+{
+	int32					LevelIndex		= -1;
+	UParticleLODLevel*	CreatedLODLevel	= NULL;
+
+	if (LODLevels.Num() == 0)
+	{
+		LODLevel = 0;
+	}
+
+	// Is the requested index outside a viable range?
+	if ((LODLevel < 0) || (LODLevel > LODLevels.Num()))
+	{
+		return -1;
+	}
+
+	// NextHighestLODLevel is the one that will be 'copied'
+	UParticleLODLevel*	NextHighestLODLevel	= NULL;
+	int32 NextHighIndex = -1;
+	// NextLowestLODLevel is the one (and all ones lower than it) that will have their LOD indices updated
+	UParticleLODLevel*	NextLowestLODLevel	= NULL;
+	int32 NextLowIndex = -1;
+
+	// Grab the two surrounding LOD levels...
+	if (LODLevel == 0)
+	{
+		// It is being added at the front of the list... (highest)
+		if (LODLevels.Num() > 0)
+		{
+			NextHighestLODLevel = LODLevels[0];
+			NextHighIndex = 0;
+			NextLowestLODLevel = NextHighestLODLevel;
+			NextLowIndex = 0;
+		}
+	}
+	else
+	if (LODLevel > 0)
+	{
+		NextHighestLODLevel = LODLevels[LODLevel - 1];
+		NextHighIndex = LODLevel - 1;
+		if (LODLevel < LODLevels.Num())
+		{
+			NextLowestLODLevel = LODLevels[LODLevel];
+			NextLowIndex = LODLevel;
+		}
+	}
+	
+	// Update the LODLevel index for the lower levels and
+	// offset the LOD validity flags for the modules...
+	if (NextLowestLODLevel)
+	{
+		//NextLowestLODLevel->ConditionalPostLoad();
+		for (int32 LowIndex = LODLevels.Num() - 1; LowIndex >= NextLowIndex; LowIndex--)
+		{
+			UParticleLODLevel* LowRemapLevel = LODLevels[LowIndex];
+			if (LowRemapLevel)
+			{
+				//LowRemapLevel->SetLevelIndex(LowIndex + 1);
+			}
+		}
+	}
+
+	// Create a ParticleLODLevel
+	CreatedLODLevel = FObjectFactory::ConstructObject<UParticleLODLevel>(this);
+	//check(CreatedLODLevel);
+
+	CreatedLODLevel->Level = LODLevel;
+	CreatedLODLevel->bEnabled = true;
+	CreatedLODLevel->ConvertedModules = true;
+	CreatedLODLevel->PeakActiveParticles = 0;
+
+	// Determine where to place it...
+	if (LODLevels.Num() == 0)
+	{
+		//LODLevels.InsertZeroed(0, 1);
+		LODLevels[0] = CreatedLODLevel;
+		CreatedLODLevel->Level	= 0;
+	}
+	else
+	{
+		//LODLevels.InsertZeroed(LODLevel, 1);
+		LODLevels[LODLevel] = CreatedLODLevel;
+		CreatedLODLevel->Level = LODLevel;
+	}
+
+	if (NextHighestLODLevel)
+	{
+		//NextHighestLODLevel->ConditionalPostLoad();
+
+		// Generate from the higher LOD level
+		// if (CreatedLODLevel->GenerateFromLODLevel(NextHighestLODLevel, 100.0, bGenerateModuleData) == false)
+		// {
+		// 	UE_LOG(LogParticles, Warning, TEXT("Failed to generate LOD level %d from level %d"), LODLevel, NextHighestLODLevel->Level);
+		// }
+	}
+	else
+	{
+		// Create the RequiredModule
+		UParticleModuleRequired* RequiredModule = FObjectFactory::ConstructObject<UParticleModuleRequired>(GetOuter());
+		//check(RequiredModule);
+		RequiredModule->SetToSensibleDefaults(this);
+		CreatedLODLevel->RequiredModule	= RequiredModule;
+
+		// The SpawnRate for the required module
+		RequiredModule->bUseLocalSpace			= false;
+		RequiredModule->bKillOnDeactivate		= false;
+		RequiredModule->bKillOnCompleted		= false;
+		RequiredModule->EmitterDuration			= 1.0f;
+		RequiredModule->EmitterLoops			= 0;
+		RequiredModule->ParticleBurstMethod		= EPBM_Instant;
+#if WITH_EDITORONLY_DATA
+		RequiredModule->ModuleEditorColor		= FColor::MakeRandomColor();
+#endif // WITH_EDITORONLY_DATA
+		RequiredModule->InterpolationMethod		= PSUVIM_None;
+		RequiredModule->SubImages_Horizontal	= 1;
+		RequiredModule->SubImages_Vertical		= 1;
+		RequiredModule->bScaleUV				= false;
+		RequiredModule->RandomImageTime			= 0.0f;
+		RequiredModule->RandomImageChanges		= 0;
+		RequiredModule->bEnabled				= true;
+
+		RequiredModule->LODValidity = (1 << LODLevel);
+
+		// There must be a spawn module as well...
+		UParticleModuleSpawn* SpawnModule = FObjectFactory::ConstructObject<UParticleModuleSpawn>(GetOuter());
+		//check(SpawnModule);
+		CreatedLODLevel->SpawnModule = SpawnModule;
+		SpawnModule->LODValidity = (1 << LODLevel);
+		float ConstantSpawn	= (SpawnModule->Rate);
+		ConstantSpawn				= 10;
+		//ConstantSpawn->bIsDirty					= true;
+		SpawnModule->BurstList.Empty();
+
+		// Copy the TypeData module
+		CreatedLODLevel->TypeDataModule			= NULL;
+	}
+
+	LevelIndex	= CreatedLODLevel->Level;
+
+	//MarkPackageDirty();
+
+	return LevelIndex;
+}
+
+bool UParticleEmitter::IsLODLevelValid(int32 LODLevel)
+{
+    for (int32 LODIndex = 0; LODIndex < LODLevels.Num(); LODIndex++)
+    {
+        UParticleLODLevel* CheckLODLevel	= LODLevels[LODIndex];
+        if (CheckLODLevel->Level == LODLevel)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
 
 UParticleLODLevel* UParticleEmitter::GetCurrentLODLevel(FParticleEmitterInstance* Instance)
 {
     return Instance->CurrentLODLevel;
+}
+
+UParticleLODLevel* UParticleEmitter::GetLODLevel(int32 LODLevel)
+{
+    if (LODLevel >= LODLevels.Num())
+    {
+        return NULL;
+    }
+    return LODLevels[LODLevel];
+}
+
+void UParticleEmitter::Build()
+{
+    const int32 LODCount = LODLevels.Num();
+    if ( LODCount > 0 )
+    {
+        UParticleLODLevel* HighLODLevel = LODLevels[0];
+        //check(HighLODLevel);
+        if (HighLODLevel->TypeDataModule != nullptr)
+        {
+            if(HighLODLevel->TypeDataModule->RequiresBuild())
+            {
+                FParticleEmitterBuildInfo EmitterBuildInfo;
+                HighLODLevel->TypeDataModule->Build( EmitterBuildInfo );
+            }
+
+            // Allow TypeData module to cache pointers to modules
+            HighLODLevel->TypeDataModule->CacheModuleInfo(this);
+        }
+
+        // Cache particle size/offset data for all LOD Levels
+        CacheEmitterModuleInfo();
+    }
+}
+
+void UParticleEmitter::CacheEmitterModuleInfo()
+{
+	// This assert makes sure that packing is as expected.
+	// Added FBaseColor...
+	// Linear color change
+	// Added Flags field
+
+	bRequiresLoopNotification = false;
+	bAxisLockEnabled = false;
+	bMeshRotationActive = false;
+	LockAxisFlags = EPAL_NONE;
+	ModuleOffsetMap.Empty();
+	ModuleInstanceOffsetMap.Empty();
+	ModuleRandomSeedInstanceOffsetMap.Empty();
+	ModulesNeedingInstanceData.Empty();
+	ModulesNeedingRandomSeedInstanceData.Empty();
+	MeshMaterials.Empty();
+	DynamicParameterDataOffset = 0;
+	LightDataOffset = 0;
+	LightVolumetricScatteringIntensity = 0;
+	CameraPayloadOffset = 0;
+	ParticleSize = sizeof(FBaseParticle);
+	ReqInstanceBytes = 0;
+	PivotOffset = FVector2D(-0.5f, -0.5f);
+	TypeDataOffset = 0;
+	TypeDataInstanceOffset = -1;
+	SubUVAnimation = nullptr;
+
+	UParticleLODLevel* HighLODLevel = GetLODLevel(0);
+	//check(HighLODLevel);
+
+	UParticleModuleTypeDataBase* HighTypeData = HighLODLevel->TypeDataModule;
+	if (HighTypeData)
+	{
+		int32 ReqBytes = HighTypeData->RequiredBytes(static_cast<UParticleModuleTypeDataBase*>(nullptr));
+		if (ReqBytes)
+		{
+			TypeDataOffset = ParticleSize;
+			ParticleSize += ReqBytes;
+		}
+
+		int32 TempInstanceBytes = HighTypeData->RequiredBytesPerInstance();
+		if (TempInstanceBytes)
+		{
+			TypeDataInstanceOffset = ReqInstanceBytes;
+			ReqInstanceBytes += TempInstanceBytes;
+		}
+	}
+
+	// Grab required module
+	UParticleModuleRequired* RequiredModule = HighLODLevel->RequiredModule;
+	//check(RequiredModule);
+	// mesh rotation active if alignment is set
+	//bMeshRotationActive = (RequiredModule->ScreenAlignment == PSA_Velocity || RequiredModule->ScreenAlignment == PSA_AwayFromCenter);
+
+	// NOTE: This code assumes that the same module order occurs in all LOD levels
+
+	for (int32 ModuleIdx = 0; ModuleIdx < HighLODLevel->Modules.Num(); ModuleIdx++)
+	{
+		UParticleModule* ParticleModule = HighLODLevel->Modules[ModuleIdx];
+		//check(ParticleModule);
+
+		// Loop notification?
+		bRequiresLoopNotification |= (ParticleModule->bEnabled && ParticleModule->RequiresLoopingNotification());
+
+		if (ParticleModule->IsA(UParticleModuleTypeDataBase::StaticClass()) == false)
+		{
+			int32 ReqBytes = ParticleModule->RequiredBytes(HighTypeData);
+			if (ReqBytes)
+			{
+				ModuleOffsetMap.Add(ParticleModule, ParticleSize);
+				// if (ParticleModule->IsA(UParticleModuleParameterDynamic::StaticClass()) && (DynamicParameterDataOffset == 0))
+				// {
+				// 	DynamicParameterDataOffset = ParticleSize;
+				// }
+				// if (ParticleModule->IsA(UParticleModuleLight::StaticClass()) && (LightDataOffset == 0))
+				// {
+				// 	UParticleModuleLight* ParticleModuleLight = Cast<UParticleModuleLight>(ParticleModule);
+				// 	LightVolumetricScatteringIntensity = ParticleModuleLight->VolumetricScatteringIntensity;
+				// 	LightDataOffset = ParticleSize;
+				// }
+				// if (ParticleModule->IsA(UParticleModuleCameraOffset::StaticClass()) && (CameraPayloadOffset == 0))
+				// {
+				// 	CameraPayloadOffset = ParticleSize;
+				// }
+				ParticleSize += ReqBytes;
+			}
+
+			int32 TempInstanceBytes = ParticleModule->RequiredBytesPerInstance();
+			if (TempInstanceBytes > 0)
+			{
+				// Add the high-lodlevel offset to the lookup map
+				ModuleInstanceOffsetMap.Add(ParticleModule, ReqInstanceBytes);
+				// Remember that this module has emitter-instance data
+				ModulesNeedingInstanceData.Add(ParticleModule);
+
+				// Add all the other LODLevel modules, using the same offset.
+				// This removes the need to always also grab the HighestLODLevel pointer.
+				for (int32 LODIdx = 1; LODIdx < LODLevels.Num(); LODIdx++)
+				{
+					UParticleLODLevel* CurLODLevel = LODLevels[LODIdx];
+					ModuleInstanceOffsetMap.Add(CurLODLevel->Modules[ModuleIdx], ReqInstanceBytes);
+				}
+				ReqInstanceBytes += TempInstanceBytes;
+			}
+
+			// Add space for per instance random seed value if required
+			if (ParticleModule->bSupportsRandomSeed)
+			{
+				// Add the high-lodlevel offset to the lookup map
+				ModuleRandomSeedInstanceOffsetMap.Add(ParticleModule, ReqInstanceBytes);
+				// Remember that this module has emitter-instance data
+				ModulesNeedingRandomSeedInstanceData.Add(ParticleModule);
+
+				// Add all the other LODLevel modules, using the same offset.
+				// This removes the need to always also grab the HighestLODLevel pointer.
+				for (int32 LODIdx = 1; LODIdx < LODLevels.Num(); LODIdx++)
+				{
+					UParticleLODLevel* CurLODLevel = LODLevels[LODIdx];
+					ModuleRandomSeedInstanceOffsetMap.Add(CurLODLevel->Modules[ModuleIdx], ReqInstanceBytes);
+				}
+
+				ReqInstanceBytes += sizeof(FParticleRandomSeedInstancePayload);
+			}
+		}
+
+		// if (ParticleModule->IsA(UParticleModuleOrientationAxisLock::StaticClass()))
+		// {
+		// 	UParticleModuleOrientationAxisLock* Module_AxisLock = CastChecked<UParticleModuleOrientationAxisLock>(ParticleModule);
+		// 	bAxisLockEnabled = Module_AxisLock->bEnabled;
+		// 	LockAxisFlags = Module_AxisLock->LockAxisFlags;
+		// }
+		// else if (ParticleModule->IsA(UParticleModulePivotOffset::StaticClass()))
+		// {
+		// 	PivotOffset += Cast<UParticleModulePivotOffset>(ParticleModule)->PivotOffset;
+		// }
+		// else if (ParticleModule->IsA(UParticleModuleMeshMaterial::StaticClass()))
+		// {
+		// 	UParticleModuleMeshMaterial* MeshMaterialModule = CastChecked<UParticleModuleMeshMaterial>(ParticleModule);
+		// 	if (MeshMaterialModule->bEnabled)
+		// 	{
+		// 		MeshMaterials = MeshMaterialModule->MeshMaterials;
+		// 	}
+		// }
+		// else if (ParticleModule->IsA(UParticleModuleSubUV::StaticClass()))
+		// {
+		// 	USubUVAnimation* ModuleSubUVAnimation = Cast<UParticleModuleSubUV>(ParticleModule)->Animation;
+		// 	SubUVAnimation = ModuleSubUVAnimation && ModuleSubUVAnimation->SubUVTexture && ModuleSubUVAnimation->IsBoundingGeometryValid()
+		// 		? ModuleSubUVAnimation
+		// 		: NULL;
+		// }
+		// // Perform validation / fixup on some modules that can cause crashes if LODs / Modules are out of sync
+		// // This should only be applied on uncooked builds to avoid wasting cycles
+		// else if ( !FPlatformProperties::RequiresCookedData() )
+		// {
+		// 	if (ParticleModule->IsA(UParticleModuleLocationBoneSocket::StaticClass()))
+		// 	{
+		// 		UParticleModuleLocationBoneSocket::ValidateLODLevels(this, ModuleIdx);
+		// 	}
+		// }
+
+		// Set bMeshRotationActive if module says so
+		if(!bMeshRotationActive && ParticleModule->TouchesMeshRotation())
+		{
+			bMeshRotationActive = true;
+		}
+	}
+}
+
+/*-----------------------------------------------------------------------------
+    UParticleSpriteEmitter implementation.
+-----------------------------------------------------------------------------*/
+UParticleSpriteEmitter::UParticleSpriteEmitter()
+{
+}
+
+FParticleEmitterInstance* UParticleSpriteEmitter::CreateInstance(UParticleSystemComponent* InComponent)
+{
+    // If this emitter was cooked out or has no valid LOD levels don't create an instance for it.
+    if ((bCookedOut == true) || (LODLevels.Num() == 0))
+    {
+        return NULL;
+    }
+
+    FParticleEmitterInstance* Instance = 0;
+
+    UParticleLODLevel* LODLevel	= GetLODLevel(0);
+    //check(LODLevel);
+
+    if (LODLevel->TypeDataModule)
+    {
+        //@todo. This will NOT work for trails/beams!
+        Instance = LODLevel->TypeDataModule->CreateInstance(this, InComponent);
+    }
+    else
+    {
+        //check(InComponent);
+        Instance = new FParticleSpriteEmitterInstance();
+        //check(Instance);
+        Instance->InitParameters(this, InComponent);
+    }
+
+    if (Instance)
+    {
+        Instance->CurrentLODLevelIndex	= 0;
+        Instance->CurrentLODLevel		= LODLevels[Instance->CurrentLODLevelIndex];
+        Instance->Init();
+    }
+
+    return Instance;
+}
+
+// void UParticleSpriteEmitter::SetToSensibleDefaults()
+// {
+//     UParticleLODLevel* LODLevel = LODLevels[0];
+//
+// 	// Spawn rate
+// 	LODLevel->SpawnModule->LODValidity = 1;
+// 	UDistributionFloatConstant* SpawnRateDist = Cast<UDistributionFloatConstant>(LODLevel->SpawnModule->Rate.Distribution);
+// 	if (SpawnRateDist)
+// 	{
+// 		SpawnRateDist->Constant = 20.f;
+// 	}
+//
+// 	// Create basic set of modules
+//
+// 	// Lifetime module
+// 	UParticleModuleLifetime* LifetimeModule = NewObject<UParticleModuleLifetime>(GetOuter());
+// 	UDistributionFloatUniform* LifetimeDist = Cast<UDistributionFloatUniform>(LifetimeModule->Lifetime.Distribution);
+// 	if (LifetimeDist)
+// 	{
+// 		LifetimeDist->Min = 1.0f;
+// 		LifetimeDist->Max = 1.0f;
+// 		LifetimeDist->bIsDirty = true;
+// 	}
+// 	LifetimeModule->LODValidity = 1;
+// 	LODLevel->Modules.Add(LifetimeModule);
+//
+// 	// Size module
+// 	UParticleModuleSize* SizeModule = NewObject<UParticleModuleSize>(GetOuter());
+// 	UDistributionVectorUniform* SizeDist = Cast<UDistributionVectorUniform>(SizeModule->StartSize.Distribution);
+// 	if (SizeDist)
+// 	{
+// 		SizeDist->Min = FVector(25.f, 25.f, 25.f);
+// 		SizeDist->Max = FVector(25.f, 25.f, 25.f);
+// 		SizeDist->bIsDirty = true;
+// 	}
+// 	SizeModule->LODValidity = 1;
+// 	LODLevel->Modules.Add(SizeModule);
+//
+// 	// Initial velocity module
+// 	UParticleModuleVelocity* VelModule = NewObject<UParticleModuleVelocity>(GetOuter());
+// 	UDistributionVectorUniform* VelDist = Cast<UDistributionVectorUniform>(VelModule->StartVelocity.Distribution);
+// 	if (VelDist)
+// 	{
+// 		VelDist->Min = FVector(-10.f, -10.f, 50.f);
+// 		VelDist->Max = FVector(10.f, 10.f, 100.f);
+// 		VelDist->bIsDirty = true;
+// 	}
+// 	VelModule->LODValidity = 1;
+// 	LODLevel->Modules.Add(VelModule);
+//
+// 	// Color over life module
+// 	UParticleModuleColorOverLife* ColorModule = NewObject<UParticleModuleColorOverLife>(GetOuter());
+// 	UDistributionVectorConstantCurve* ColorCurveDist = Cast<UDistributionVectorConstantCurve>(ColorModule->ColorOverLife.Distribution);
+// 	if (ColorCurveDist)
+// 	{
+// 		// Add two points, one at time 0.0f and one at 1.0f
+// 		for (int32 Key = 0; Key < 2; Key++)
+// 		{
+// 			int32	KeyIndex = ColorCurveDist->CreateNewKey(Key * 1.0f);
+// 			for (int32 SubIndex = 0; SubIndex < 3; SubIndex++)
+// 			{
+// 				ColorCurveDist->SetKeyOut(SubIndex, KeyIndex, 1.0f);
+// 			}
+// 		}
+// 		ColorCurveDist->bIsDirty = true;
+// 	}
+// 	ColorModule->AlphaOverLife.Distribution = NewObject<UDistributionFloatConstantCurve>(ColorModule);
+// 	UDistributionFloatConstantCurve* AlphaCurveDist = Cast<UDistributionFloatConstantCurve>(ColorModule->AlphaOverLife.Distribution);
+// 	if (AlphaCurveDist)
+// 	{
+// 		// Add two points, one at time 0.0f and one at 1.0f
+// 		for (int32 Key = 0; Key < 2; Key++)
+// 		{
+// 			int32	KeyIndex = AlphaCurveDist->CreateNewKey(Key * 1.0f);
+// 			if (Key == 0)
+// 			{
+// 				AlphaCurveDist->SetKeyOut(0, KeyIndex, 1.0f);
+// 			}
+// 			else
+// 			{
+// 				AlphaCurveDist->SetKeyOut(0, KeyIndex, 0.0f);
+// 			}
+// 		}
+// 		AlphaCurveDist->bIsDirty = true;
+// 	}
+// 	ColorModule->LODValidity = 1;
+// 	LODLevel->Modules.Add(ColorModule);
+// }
+
+/*-----------------------------------------------------------------------------
+    UParticleSystem implementation.
+-----------------------------------------------------------------------------*/
+
+UParticleSystem::UParticleSystem()
+    : bAnyEmitterLoopsForever(false)
+    , bIsImmortal(false)
+    , bWillBecomeZombie(false)
+{
+#if WITH_EDITORONLY_DATA
+    ThumbnailDistance = 200.0;
+    ThumbnailWarmup = 1.0;
+#endif // WITH_EDITORONLY_DATA
+    UpdateTime_FPS = 60.0f;
+    UpdateTime_Delta = 1.0f/60.0f;
+    WarmupTime = 0.0f;
+    WarmupTickRate = 0.0f;
+#if WITH_EDITORONLY_DATA
+    EditorLODSetting = 0;
+#endif // WITH_EDITORONLY_DATA
+    FixedRelativeBoundingBox.MinLocation = FVector(-1.0f, -1.0f, -1.0f);
+    FixedRelativeBoundingBox.MaxLocation = FVector(1.0f, 1.0f, 1.0f);
+    
+    LODMethod = PARTICLESYSTEMLODMETHOD_Automatic;
+    LODDistanceCheckTime = 0.25f;
+    bRegenerateLODDuplicate = false;
+    ThumbnailImageOutOfDate = true;
+
+    MacroUVPosition = FVector(0.0f, 0.0f, 0.0f);
+
+    MacroUVRadius = 200.0f;
+    bAutoDeactivate = true;
+    MinTimeBetweenTicks = 0;
+    MaxPoolSize = 32;
+
+
+    bAllowManagedTicking = true;
+}
+
+ParticleSystemLODMethod UParticleSystem::GetCurrentLODMethod()
+{
+    return ParticleSystemLODMethod(LODMethod);
+}
+
+int32 UParticleSystem::GetLODLevelCount()
+{
+    return LODDistances.Num();
+}
+
+float UParticleSystem::GetLODDistance(int32 LODLevelIndex)
+{
+    if (LODLevelIndex >= LODDistances.Num())
+    {
+        return -1.0f;
+    }
+
+    return LODDistances[LODLevelIndex];
+}
+
+void UParticleSystem::SetCurrentLODMethod(ParticleSystemLODMethod InMethod)
+{
+    LODMethod = InMethod;
+}
+
+bool UParticleSystem::SetLODDistance(int32 LODLevelIndex, float InDistance)
+{
+    if (LODLevelIndex >= LODDistances.Num())
+    {
+        return false;
+    }
+
+    LODDistances[LODLevelIndex] = InDistance;
+
+    return true;
 }
 
 bool UParticleSystem::CanBePooled()const

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleEmitter.h
@@ -76,7 +76,7 @@ class UParticleEmitter : public UObject
 {
     DECLARE_CLASS(UParticleEmitter, UObject)
 public:
-    UParticleEmitter() = default;
+    UParticleEmitter();
     ~UParticleEmitter() = default;
     //~=============================================================================
     //	General variables
@@ -183,21 +183,25 @@ public:
     TArray<UParticleModule*> ModulesNeedingRandomSeedInstanceData;
 
     /** SubUV animation asset to use for cutout geometry. */
-    //class USubUVAnimation* RESTRICT SubUVAnimation;
+    class USubUVAnimation* __restrict SubUVAnimation;
 
     // UObject Interface
     //virtual void Serialize(FArchive& Ar)override;
+    //virtual void PostLoad() override;
 
     // @todo document
-    //virtual FParticleEmitterInstance* CreateInstance(UParticleSystemComponent* InComponent);
+    virtual FParticleEmitterInstance* CreateInstance(UParticleSystemComponent* InComponent);
+    
+    // Sets up this emitter with sensible defaults so we can see some particles as soon as its created.
+    //virtual void SetToSensibleDefaults() {}
+    
+    virtual void UpdateModuleLists();
 
-    //virtual void UpdateModuleLists();
+    void SetEmitterName(FName Name);
 
-    //void SetEmitterName(FName Name);
+    FName& GetEmitterName();
 
-    //FName& GetEmitterName();
-
-    //virtual	void SetLODCount(int32 LODCount);
+    virtual	void SetLODCount(int32 LODCount);
 
     /** CreateLODLevel
      *	Creates the given LOD level.
@@ -206,7 +210,7 @@ public:
      *
      *	@return The index of the created LOD level
      */
-    //int32 CreateLODLevel(int32 LODLevel, bool bGenerateModuleData = true);
+    int32 CreateLODLevel(int32 LODLevel, bool bGenerateModuleData = true);
 
     /** IsLODLevelValid
      *	Returns true if the given LODLevel is one of the array entries.
@@ -216,7 +220,7 @@ public:
      *	@return false if the requested LODLevel is not valid.
      *			true if the requested LODLevel is valid.
      */
-    //bool IsLODLevelValid(int32 LODLevel);
+    bool IsLODLevelValid(int32 LODLevel);
 
     /** GetCurrentLODLevel
     *	Returns the currently set LODLevel. Intended for game-time usage.
@@ -243,7 +247,7 @@ public:
      *	@return NULL if the requested LODLevel is not valid.
      *			The pointer to the requested UParticleLODLevel if valid.
      */
-    //UParticleLODLevel* GetLODLevel(int32 LODLevel);
+    UParticleLODLevel* GetLODLevel(int32 LODLevel);
 
     /**
      *	Autogenerate the lowest LOD level...
@@ -276,10 +280,10 @@ public:
     /**
      * Builds data needed for simulation by the emitter from all modules.
      */
-    //void Build();
+    void Build();
 
     /** Pre-calculate data size/offset and other info from modules in this Emitter */
-    //void CacheEmitterModuleInfo();
+    void CacheEmitterModuleInfo();
 
     /**
      *   Calculate spawn rate multiplier based on global effects quality level and emitter's quality scale

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleLODLevel.h
@@ -13,7 +13,7 @@ class UParticleLODLevel : public UObject
 {
     DECLARE_CLASS(UParticleLODLevel, UObject)
 public:
-    UParticleLODLevel() = default;
+    UParticleLODLevel();
     ~UParticleLODLevel() = default;
     
     /** The index value of the LOD level												*/
@@ -79,7 +79,7 @@ public:
     //~ End UObject Interface
 
     // @todo document
-    //virtual void	UpdateModuleLists();
+    virtual void UpdateModuleLists();
 
     // @todo document
     //virtual bool	GenerateFromLODLevel(UParticleLODLevel* SourceLODLevel, float Percentage, bool bGenerateModuleData = true);
@@ -91,16 +91,16 @@ public:
      *
      *	@return		The maximum active particle count for the LOD level.
      */
-    //virtual int32	CalculateMaxActiveParticleCount();
+    virtual int32	CalculateMaxActiveParticleCount();
 
     /** Update to the new SpawnModule method */
     //void	ConvertToSpawnModule();
 
     /** @return the index of the given module if it is contained in the LOD level */
-    //int32		GetModuleIndex(UParticleModule* InModule);
+    int32 GetModuleIndex(UParticleModule* InModule);
 
     /** @return the module at the given index if it is contained in the LOD level */
-    //UParticleModule* GetModuleAtIndex(int32 InIndex);
+    UParticleModule* GetModuleAtIndex(int32 InIndex);
 
     /**
      *	Sets the LOD 'Level' to the given value, properly updating the modules LOD validity settings.
@@ -128,7 +128,7 @@ public:
      * Compiles all modules for this LOD level.
      * @param EmitterBuildInfo - Where to store emitter information.
      */
-    //void CompileModules(struct FParticleEmitterBuildInfo& EmitterBuildInfo);
+    void CompileModules(struct FParticleEmitterBuildInfo& EmitterBuildInfo);
 
     /**
      * Append all used materials to the material list.

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSpriteEmitter.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSpriteEmitter.h
@@ -1,0 +1,36 @@
+﻿#pragma once
+
+#include "UObject/ObjectMacros.h"
+#include "Particles/ParticleEmitter.h"
+
+class UParticleSystemComponent;
+
+enum EParticleScreenAlignment : int
+{
+    PSA_FacingCameraPosition,
+    PSA_Square,
+    PSA_Rectangle,
+    PSA_Velocity,
+    PSA_AwayFromCenter,
+    PSA_TypeSpecific,
+    PSA_FacingCameraDistanceBlend,
+    PSA_MAX,
+};
+
+class UParticleSpriteEmitter : public UParticleEmitter
+{
+    DECLARE_CLASS(UParticleSpriteEmitter, UParticleEmitter)
+
+    UParticleSpriteEmitter();
+    virtual ~UParticleSpriteEmitter()=default;
+
+    //~ Begin UObject Interface
+    //virtual void PostLoad() override;
+    //~ End UObject Interface
+
+    //~ Begin UParticleEmitter Interface
+    virtual FParticleEmitterInstance* CreateInstance(UParticleSystemComponent* InComponent) override;
+    //virtual void SetToSensibleDefaults() override;
+    //~ End UParticleEmitter Interface
+};
+

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleSystem.h
@@ -100,7 +100,7 @@ class UParticleSystem : public UObject
 {
     DECLARE_CLASS(UParticleSystem, UObject)
 public:
-    UParticleSystem() = default;
+    UParticleSystem();
     ~UParticleSystem() = default;
 
     /** Max number of components of this system to keep resident in the world component pool. */
@@ -330,17 +330,17 @@ public:
     /**
      * Set the time to delay spawning the particle system
      */
-    //void SetDelay(float InDelay);
+    void SetDelay(float InDelay);
 
     /** Return the currently set LOD method											*/
-    //virtual enum ParticleSystemLODMethod GetCurrentLODMethod();
+    virtual enum ParticleSystemLODMethod GetCurrentLODMethod();
 
     /**
      *	Return the number of LOD levels for this particle system
      *
      *	@return	The number of LOD levels in the particle system
      */
-    //virtual int32 GetLODLevelCount();
+    virtual int32 GetLODLevelCount();
 
     /**
      *	Return the distance for the given LOD level
@@ -350,14 +350,14 @@ public:
      *	@return	-1.0f			If the index is invalid
      *			Distance		The distance set for the LOD level
      */
-    //virtual float GetLODDistance(int32 LODLevelIndex);
+    virtual float GetLODDistance(int32 LODLevelIndex);
 
     /**
      *	Set the LOD method
      *
      *	@param	InMethod		The desired method
      */
-    //virtual void SetCurrentLODMethod(ParticleSystemLODMethod InMethod);
+    virtual void SetCurrentLODMethod(ParticleSystemLODMethod InMethod);
 
     /**
      *	Set the distance for the given LOD index
@@ -368,19 +368,19 @@ public:
      *	@return	true			If successful
      *			false			Invalid LODLevelIndex
      */
-    //virtual bool SetLODDistance(int32 LODLevelIndex, float InDistance);
+    virtual bool SetLODDistance(int32 LODLevelIndex, float InDistance);
 
     /**
      * Builds all emitters in the particle system.
      */
-    //void BuildEmitters();
+    void BuildEmitters();
 
     /**
     Returns true if this system contains an emitter of the pasesd type.
     @ param TypeData - The emitter type to check for. Must be a child class of UParticleModuleTypeDataBase
     */
     //UFUNCTION(BlueprintCallable, Category = "Particle System")
-    //bool ContainsEmitterType(UClass* TypeData);
+    bool ContainsEmitterType(UClass* TypeData);
 
     /** Returns true if the particle system is looping (contains one or more looping emitters) */
     bool IsLooping() const { return bAnyEmitterLoopsForever; }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleEmitterInstances.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleEmitterInstances.h
@@ -6,6 +6,7 @@
 #include "Math/Matrix.h"
 #include "Math/Transform.h"
 
+struct FDynamicEmitterDataBase;
 struct FDynamicEmitterReplayDataBase;
 struct FBaseParticle;
 struct FParticleRandomSeedInstancePayload;
@@ -400,10 +401,10 @@ public:
     /**
      *	Retrieves the dynamic data for the emitter
      */
-   /* virtual FDynamicEmitterDataBase* GetDynamicData(bool bSelected, ERHIFeatureLevel::Type InFeatureLevel)
+    virtual FDynamicEmitterDataBase* GetDynamicData(bool bSelected)
     {
         return NULL;
-    }*/
+    }
 
     /**
      *	Retrieves replay data for the emitter
@@ -691,4 +692,56 @@ struct FParticleEmitterBuildInfo
 
     /** Default constructor. */
     FParticleEmitterBuildInfo();
+};
+
+/*-----------------------------------------------------------------------------
+    ParticleSpriteEmitterInstance
+-----------------------------------------------------------------------------*/
+struct FParticleSpriteEmitterInstance : public FParticleEmitterInstance
+{
+    /** Constructor	*/
+    FParticleSpriteEmitterInstance();
+
+    /** Destructor	*/
+    virtual ~FParticleSpriteEmitterInstance();
+
+    /**
+     *	Retrieves the dynamic data for the emitter
+     */
+    virtual FDynamicEmitterDataBase* GetDynamicData(bool bSelected) override;
+
+    /**
+     *	Retrieves replay data for the emitter
+     *
+     *	@return	The replay data, or NULL on failure
+     */
+    virtual FDynamicEmitterReplayDataBase* GetReplayData() override;
+
+    /**
+     *	Retrieve the allocated size of this instance.
+     *
+     *	@param	OutNum			The size of this instance
+     *	@param	OutMax			The maximum size of this instance
+     */
+    //virtual void GetAllocatedSize(int32& OutNum, int32& OutMax) override;
+
+    /**
+     * Returns the size of the object/ resource for display to artists/ LDs in the Editor.
+     *
+     * @param	Mode	Specifies which resource size should be displayed. ( see EResourceSizeMode::Type )
+     * @return  Size of resource as to be displayed to artists/ LDs in the Editor.
+     */
+    //virtual void GetResourceSizeEx(FResourceSizeEx& CumulativeResourceSize) override;
+
+protected:
+
+    /**
+     * Captures dynamic replay data for this particle system.
+     *
+     * @param	OutData		[Out] Data will be copied here
+     *
+     * @return Returns true if successful
+     */
+    virtual bool FillReplayData( FDynamicEmitterReplayDataBase& OutData ) override;
+
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleEmitterInstances.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleEmitterInstances.h
@@ -395,7 +395,7 @@ public:
      *
      *	@return	bool		true if GetDynamicData should continue, false if it should return NULL
      */
-    virtual bool IsDynamicDataRequired(UParticleLODLevel* CurrentLODLevel);
+    virtual bool IsDynamicDataRequired(UParticleLODLevel* InCurrentLODLevel);
 
     /**
      *	Retrieves the dynamic data for the emitter

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleHelper.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleHelper.h
@@ -134,6 +134,11 @@ inline void Particle_SetColorFromVector(const FVector& InColorVec, const float I
     OutColor.A = InAlpha;
 }
 
+// Special module indices...
+#define INDEX_TYPEDATAMODULE	(INDEX_NONE - 1)
+#define INDEX_REQUIREDMODULE	(INDEX_NONE - 2)
+#define INDEX_SPAWNMODULE		(INDEX_NONE - 3)
+
 /*-----------------------------------------------------------------------------
     FBaseParticle
 -----------------------------------------------------------------------------*/
@@ -347,8 +352,8 @@ struct FDynamicEmitterDataBase
     }
 
     /** Custom new/delete with recycling */
-    void* operator new(size_t Size);
-    void operator delete(void* RawMemory, size_t Size);
+    //void* operator new(size_t Size);
+    //void operator delete(void* RawMemory, size_t Size);
 
     // Proxy관련 내용 전부 제거 하도록 함, 원 함수 선언만 표시 목적을 위해 남겨 둠
     // DirectX로 직접 데이터를 전달하여 그리도록 하는 새로운 메서드를 만드는 것이 현재 단계에서 나을 듯

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleHelper.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleHelper.h
@@ -383,7 +383,7 @@ struct FDynamicSpriteEmitterReplayDataBase
     FVector							NormalsSphereCenter;
     FVector							NormalsCylinderDirection;
     float							InvDeltaSeconds;
-    FVector						LWCTile;
+    // FVector						LWCTile;
     int32							MaxDrawCount;
     int32							OrbitModuleOffset;
     int32							DynamicParameterDataOffset;
@@ -395,7 +395,7 @@ struct FDynamicSpriteEmitterReplayDataBase
     int32							SubImages_Vertical;
     bool						bUseLocalSpace;
     bool						bLockAxis;
-    uint8						ScreenAlignment;
+    //uint8						ScreenAlignment;
     uint8						LockAxisFlag;
     uint8						EmitterRenderMode;
     uint8						EmitterNormalsMode;

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -703,6 +703,7 @@ xcopy /y /d "$(SolutionDir)$(ProjectName)\Engine\Source\ThirdParty\FBX\lib\x64\$
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleLODLevel.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModule.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleModuleRequired.h" />
+    <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSpriteEmitter.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSystem.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\ParticleSystemRender.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Particles\Size\ParticleModuleSizeBase.h" />


### PR DESCRIPTION
- `UParticleEmitter`와 `UParticleLODLevel`의 생성자 정의가 추가되었습니다.
- `UpdateModuleLists`와 `CreateInstance` 등 이전에 비활성화되었던 함수들이 활성화되었습니다.
- `CompileModules`, `UpdateModuleLists`, `GetModuleIndex` 등 새로운 함수들이 구현되었습니다.
- 명확성을 위해 `bJustRegistered` 변수와 추가 주석이 포함되었습니다.
- EngineSIU 프로젝트에 `ParticleSpriteEmitter` 관련 헤더들이 포함되었습니다.
- `FParticleEmitterInstance`의 초기화 및 업데이트 로직이 확장되었습니다.
- `ParticleSystemComponent`의 `EmitterDelay` 변수와 `TArray`의 `AddZeroed` 함수와 같은 유틸리티가 추가되었습니다.
- 파티클 스폰 및 정렬 프로세스에 대한 기능이 향상되고 버그가 수정되었습니다.
- 코드 가독성 향상을 위해 사용되지 않는 변수들이 주석 처리되었습니다.
