### PR TITLE
Add default initializer to particle modules and update related logic

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ParticleSystemComponent.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Components/ParticleSystemComponent.cpp
@@ -6,8 +6,10 @@
 #include "Particles/ParticleSpriteEmitter.h"
 #include "Particles/ParticleLODLevel.h"
 #include "Particles/Spawn/ParticleModuleSpawn.h"
+#include "Particles/ParticleModuleRequired.h"
 
 #include "Engine/ParticleEmitterInstances.h"
+#include "Particles/Lifetime/ParticleModuleLifetime.h"
 #include "UObject/ObjectFactory.h"
 
 UParticleSystemComponent::UParticleSystemComponent()
@@ -23,15 +25,20 @@ UParticleSystemComponent::UParticleSystemComponent()
     UParticleSpriteEmitter* SampleEmitter = FObjectFactory::ConstructObject<UParticleSpriteEmitter>(nullptr);
     SampleEmitter->CreateLODLevel(0);
 
+    UParticleModuleRequired* SampleRequiredModule = FObjectFactory::ConstructObject<UParticleModuleRequired>(nullptr);
+    SampleEmitter->GetLODLevel(0)->Modules.Add(SampleRequiredModule);
+    
     UParticleModuleSpawn* SampleSpawnModule = FObjectFactory::ConstructObject<UParticleModuleSpawn>(nullptr);
-
     SampleEmitter->GetLODLevel(0)->Modules.Add(SampleSpawnModule);
 
+    UParticleModuleLifetime* SampleLifetimeModule = FObjectFactory::ConstructObject<UParticleModuleLifetime>(nullptr);
+    SampleEmitter->GetLODLevel(0)->Modules.Add(SampleLifetimeModule);
+    
     Template->Emitters.Add(SampleEmitter);
     
     FParticleEmitterInstance* SampleInstance = SampleEmitter->CreateInstance(this);
     EmitterInstances.Add(SampleInstance);
-
+    
     bSuppressSpawning = false;
 
     DeltaTimeTick = 0.016f;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModules_Location.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Location/ParticleModules_Location.cpp
@@ -19,6 +19,7 @@ UParticleModuleLocation::UParticleModuleLocation()
 	bSpawnModule = true;
 	bSupported3DDrawMode = true;
 	DistributeOverNPoints = 0.0f;
+    InitializeDefaults();
 }
 
 void UParticleModuleLocation::InitializeDefaults()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/ParticleModules.cpp
@@ -101,6 +101,7 @@ UParticleModuleRequired::UParticleModuleRequired()
     bSupportLargeWorldCoordinates = true;
     UVFlippingMode = EParticleUVFlipMode::None;
     AlphaThreshold = 0.1f;
+    InitializeDefaults();
 }
 
 void UParticleModuleRequired::InitializeDefaults()
@@ -155,6 +156,7 @@ UParticleModuleLifetime::UParticleModuleLifetime()
     : Super()
 {
     bSpawnModule = true;
+    InitializeDefaults();
 }
 
 void UParticleModuleLifetime::InitializeDefaults()
@@ -163,7 +165,7 @@ void UParticleModuleLifetime::InitializeDefaults()
     // {
     //     Lifetime.Distribution = NewObject<UDistributionFloatUniform>(this, TEXT("DistributionLifetime"));
     // }
-    Lifetime = 1.0f;
+    Lifetime = 10.0f;
 }
 
 void UParticleModuleLifetime::CompileModule( struct FParticleEmitterBuildInfo& EmitterInfo )

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModules_Spawn.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Spawn/ParticleModules_Spawn.cpp
@@ -16,12 +16,15 @@ UParticleModuleSpawn::UParticleModuleSpawn()
     bProcessSpawnRate = true;
     LODDuplicate = false;
     bApplyGlobalSpawnRateScale = true;
+    InitializeDefaults();
 }
 
 void UParticleModuleSpawn::InitializeDefaults()
 {
     // Initialize Values
     Rate = 10.f;
+    RateScale = 1.f;
+    BurstScale = 1.f;
 }
 
 bool UParticleModuleSpawn::GetSpawnAmount(FParticleEmitterInstance* Owner,

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModules_Velocity.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Particles/Velocity/ParticleModules_Velocity.cpp
@@ -20,6 +20,7 @@ UParticleModuleVelocityBase::UParticleModuleVelocityBase()
 UParticleModuleVelocity::UParticleModuleVelocity()
 {
 	bSpawnModule = true;
+    InitializeDefaults();
 }
 
 void UParticleModuleVelocity::InitializeDefaults()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleEmitterInstances.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ParticleEmitterInstances.cpp
@@ -719,6 +719,7 @@ void FParticleEmitterInstance::ForceUpdateBoundingBox()
 
 uint32 FParticleEmitterInstance::RequiredBytes()
 {
+    //SubUV Particle있으면 구현필요할듯
     return 0;
 }
 
@@ -756,9 +757,9 @@ uint8* FParticleEmitterInstance::GetTypeDataModuleInstanceData()
     return nullptr;
 }
 
-uint32 FParticleEmitterInstance::CalculateParticleStride(uint32 ParticleSize)
+uint32 FParticleEmitterInstance::CalculateParticleStride(uint32 InParticleSize)
 {
-    return 0;
+    return InParticleSize;
 }
 
 
@@ -935,8 +936,8 @@ float FParticleEmitterInstance::Spawn(float DeltaTime)
             }*/
 
             //const FVector InitialLocation = EmitterToSimulation.GetOrigin();
-            // [TEMP] SUPER HARD CODED WHERE IS THE COUNT OUT SETTING
-            Number = 5;
+            // // [TEMP] SUPER HARD CODED WHERE IS THE COUNT OUT SETTING
+            // Number = 5;
             FVector InitialLocation(0, 0, 0);
             // Spawn particles.
             SpawnParticles(Number, StartTime, Increment, InitialLocation, FVector::ZeroVector, EventPayload);
@@ -1026,7 +1027,7 @@ void FParticleEmitterInstance::SpawnParticles(int32 Count, float StartTime, floa
                     static bool bErrorReported = false;
                     if (!bErrorReported)
                     {
-                        UE_LOG(ELogLevel::Error, TEXT("Detected null particles. Template : %s, Component %s"));
+                        //UE_LOG(ELogLevel::Error, TEXT("Detected null particles. Template : %s, Component %s"));
                         bErrorReported = true;
                     }
                     ActiveParticles = 0;


### PR DESCRIPTION
## 주요 변경사항

- 다양한 파티클 모듈(Required, Location, Spawn, Lifetime 등)에 `InitializeDefaults` 함수 추가
- 기본 초기화 로직(RateScale, BurstScale 초기 설정 등) 정리 및 추가
- `ParticleSystemComponent`에 샘플 모듈(Required, Lifetime) 추가 및 생성 로직 연결
- 불필요한 주석과 로직 정리